### PR TITLE
Add Contributors Section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,20 @@ You are free to use, modify, and distribute this project for personal or commerc
       </a>
     </td>
 </table>
+
+---
+
+
+## ✨ Contributors
+
+#### Thanks to all the wonderful contributors 💖
+
+<a href="https://github.com/soumyo-jeet/assist-ai/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=soumyo-jeet/assist-ai" />
+</a>
+
+#### See full list of contributor contribution [Contribution Graph](https://github.com/soumyo-jeet/assist-ai/graphs/contributors)  
+
 ---
 
 ## 🌟 Show Your Support


### PR DESCRIPTION
Description
This PR adds a Contributors section to the README.md to recognize and showcase all contributors, making the repository more welcoming for new contributors.

Current Problem
The README.md currently lacks a Contributors section to recognize contributors and guide new ones.

Proposed Solution
Add a Contributors section at the end of README.md
Include an auto-generated contributor badge via [contrib.rocks](https://contrib.rocks/)
Update Table of Contents to include this new section
Keep all existing content intact and improve formatting where necessary

Benefits
Recognizes contributors and shows appreciation
Makes the repository more welcoming for new contributors
Improves documentation readability and structure

Close issue #5 